### PR TITLE
Add Support for sebastian/version ^4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@v2"
@@ -69,8 +70,3 @@ jobs:
 
       - name: "Run tests with phpunit/phpunit"
         run: "./tools/phpunit --coverage-clover=coverage.xml"
-
-      - name: "Send code coverage report to Codecov.io"
-        env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-        run: "bash <(curl -s https://codecov.io/bash) || true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,43 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
-  - "pull_request"
-  - "push"
+  - pull_request
+  - push
 
-name: "CI"
+name: CI
 
 jobs:
   coding-guidelines:
-    name: "Coding Guidelines"
+    name: Coding Guidelines
 
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: "Run friendsofphp/php-cs-fixer"
-        run: "./tools/php-cs-fixer fix --dry-run --show-progress=dots --using-cache=no --verbose"
+      - name: Run friendsofphp/php-cs-fixer
+        run: ./tools/php-cs-fixer fix --dry-run --show-progress=dots --using-cache=no --verbose
 
   type-checker:
-    name: "Type Checker"
+    name: Type Checker
 
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: "Update dependencies with composer"
-        run: "./tools/composer update --no-ansi --no-interaction --no-progress"
+      - name: Update dependencies with composer
+        run: ./tools/composer update --no-ansi --no-interaction --no-progress
 
-      - name: "Run vimeo/psalm"
-        run: "./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats"
+      - name: Run vimeo/psalm
+        run: ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats
 
   tests:
-    name: "Tests"
+    name: Tests
 
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -49,24 +49,24 @@ jobs:
           - "8.2"
 
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v3"
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@v2"
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
+          php-version: ${{ matrix.php-version }}
+          coverage: pcov
 
-      - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v1"
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v1
         with:
-          path: "~/.composer/cache"
-          key: "php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}"
-          restore-keys: "php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+          path: ~/.composer/cache
+          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: "Install dependencies with composer"
         run: "./tools/composer update --no-ansi --no-interaction --no-progress"
 
-      - name: "Run tests with phpunit/phpunit"
-        run: "./tools/phpunit --coverage-clover=coverage.xml"
+      - name: Run tests with phpunit/phpunit
+        run: ./tools/phpunit --coverage-text --coverage-clover=coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,25 +43,14 @@ jobs:
       fail-fast: true
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        sebastian_version: [l3.*, 4.*]
-#        include:
-#          - php: 7.3
-#            sebastian_version: 2.*
-#        exclude:
-#          - php: 8.2
-#            sebastian_version: 2.*
-#          - php: 8.2
-#            sebastian_version: 3.*
-#          - php: 8.1
-#            sebastian_version: 2.*
-#          - php: 8.1
-#            sebastian_version: 3.*
-#          - php: 8.0
-#            sebastian_version: 4.*
-#          - php: 7.4
-#            sebastian_version: 4.*
-#          - php: 7.3
-#            sebastian_version: 4.*
+        sebastian_version: [3.*, 4.*]
+        exclude:
+          - php: 8.2
+            sebastian_version: 3.*
+          - php: 8.1
+            sebastian_version: 3.*
+          - php: 8.0
+            sebastian_version: 4.*
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,26 @@ jobs:
 
     strategy:
       matrix:
-        php-version:
-          - "7.3"
-          - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
+        version: [2.*, 3.*, 4.*]
+        include:
+          - php: 7.3
+            version: 2.*
+        exclude:
+          - php: 8.2
+            version: 2.*
+          - php: 8.2
+            version: 3.*
+          - php: 8.1
+            version: 2.*
+          - php: 8.1
+            version: 3.*
+          - php: 8.0
+            version: 4.*
+          - php: 7.4
+            version: 4.*
+          - php: 7.3
+            version: 4.*
 
     steps:
       - name: Checkout
@@ -65,8 +79,10 @@ jobs:
           key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
           restore-keys: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
-      - name: "Install dependencies with composer"
-        run: "./tools/composer update --no-ansi --no-interaction --no-progress"
+      - name: Install dependencies with composer
+        run: |
+          ./tools/composer require sebastian/version:${{ matrix.version }} --no-interaction --no-update
+          ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with phpunit/phpunit
         run: ./tools/phpunit --coverage-text --coverage-clover=coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
-        sebastian_version: [2.*, 3.*, 4.*]
+        php-version: [8.0, 8.1, 8.2]
+        sebastian_version: [l3.*, 4.*]
 #        include:
 #          - php: 7.3
 #            sebastian_version: 2.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
-
 on:
   - pull_request
   - push
@@ -7,18 +5,6 @@ on:
 name: CI
 
 jobs:
-  coding-guidelines:
-    name: Coding Guidelines
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run friendsofphp/php-cs-fixer
-        run: ./tools/php-cs-fixer fix --dry-run --show-progress=dots --using-cache=no --verbose
-
   type-checker:
     name: Type Checker
 
@@ -26,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update dependencies with composer
         run: ./tools/composer update --no-ansi --no-interaction --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
         run: ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats
 
   tests:
-    name: Tests
+    name: P${{ matrix.php }} - version ${{ matrix.sebastian_version }}
 
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
       matrix:
-        php-version: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2]
         sebastian_version: [3.*, 4.*]
         exclude:
           - php: 8.2
@@ -59,15 +59,15 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ matrix.php }}
           coverage: pcov
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache
-          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
+          key: php${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: php${{ matrix.php }}-composer-${{ matrix.dependencies }}-
 
       - name: Install dependencies with composer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: true
       matrix:
-        fail-fast: true
         php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
         sebastian_version: [2.*, 3.*, 4.*]
 #        include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,26 +41,27 @@ jobs:
 
     strategy:
       matrix:
+        fail-fast: true
         php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
-        version: [2.*, 3.*, 4.*]
-        include:
-          - php: 7.3
-            version: 2.*
-        exclude:
-          - php: 8.2
-            version: 2.*
-          - php: 8.2
-            version: 3.*
-          - php: 8.1
-            version: 2.*
-          - php: 8.1
-            version: 3.*
-          - php: 8.0
-            version: 4.*
-          - php: 7.4
-            version: 4.*
-          - php: 7.3
-            version: 4.*
+        sebastian_version: [2.*, 3.*, 4.*]
+#        include:
+#          - php: 7.3
+#            sebastian_version: 2.*
+#        exclude:
+#          - php: 8.2
+#            sebastian_version: 2.*
+#          - php: 8.2
+#            sebastian_version: 3.*
+#          - php: 8.1
+#            sebastian_version: 2.*
+#          - php: 8.1
+#            sebastian_version: 3.*
+#          - php: 8.0
+#            sebastian_version: 4.*
+#          - php: 7.4
+#            sebastian_version: 4.*
+#          - php: 7.3
+#            sebastian_version: 4.*
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies with composer
         run: |
-          ./tools/composer require sebastian/version:${{ matrix.version }} --no-interaction --no-update
+          ./tools/composer require sebastian/version:${{ matrix.sebastian_version }} --no-interaction --no-update
           ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with phpunit/phpunit

--- a/.github/workflows/format_php.yml
+++ b/.github/workflows/format_php.yml
@@ -1,0 +1,19 @@
+name: Format PHP
+
+on: pull_request
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Run php-cs-fixer
+      uses: docker://oskarstark/php-cs-fixer-ga
+
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Apply php-cs-fixer changes
+        branch: ${{ github.head_ref }}

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
             "name": "Sebastian Bergmann",
             "email": "sebastian@phpunit.de",
             "role": "lead"
+        },
+        {
+            "name": "Stefan Zweifel",
+            "email": "stefan@stefanzweifel.dev"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,11 @@
         "issues": "https://github.com/stefanzweifel/phploc/issues"
     },
     "config": {
-        "platform": {
-            "php": "8.1.0"
-        },
         "optimize-autoloader": true,
         "sort-packages": true
     },
     "require": {
-        "php": ">=7.3",
+        "php": "^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "sebastian/cli-parser": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3.0"
+            "php": "8.1.0"
         },
         "optimize-autoloader": true,
         "sort-packages": true
@@ -25,7 +25,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "sebastian/cli-parser": "^1.0",
-        "sebastian/version": "^2.0 || ^3.0",
+        "sebastian/version": "^2.0 || ^3.0 || ^4.0",
         "phpunit/php-file-iterator": "^3.0"
     },
     "autoload": {

--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -86,9 +86,20 @@ final class Application
 
     private function printVersion(): void
     {
+        $versionInstance = (new Version(self::VERSION, dirname(__DIR__)));
+        $versionString = '';
+
+        if (method_exists($versionInstance, 'asString')) {
+            $versionString = $versionInstance->asString();
+        }
+
+        if (method_exists($versionInstance, 'getVersion')) {
+            $versionString = $versionInstance->getVersion();
+        }
+
         printf(
             'phploc %s by Sebastian Bergmann.' . PHP_EOL,
-            (new Version(self::VERSION, dirname(__DIR__)))->getVersion()
+            $versionString
         );
     }
 

--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -87,7 +87,7 @@ final class Application
     private function printVersion(): void
     {
         $versionInstance = (new Version(self::VERSION, dirname(__DIR__)));
-        $versionString = '';
+        $versionString   = '';
 
         if (method_exists($versionInstance, 'asString')) {
             $versionString = $versionInstance->asString();


### PR DESCRIPTION
This PR updates the package to support `sebastian/version:^4`. Required to add Support for PHPUnit v10 to laravel-stats.

## Related Issues
- https://github.com/stefanzweifel/laravel-stats/issues/214