### PR TITLE
PHPUnit v11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         "php": "^8.0",
         "ext-dom": "*",
         "ext-json": "*",
-        "sebastian/cli-parser": "^1.0 || ^2.0",
-        "sebastian/version": "^2.0 || ^3.0 || ^4.0",
-        "phpunit/php-file-iterator": "^3.0 || ^4.0"
+        "sebastian/cli-parser": "^1.0 || ^2.0 || ^3.0",
+        "sebastian/version": "^2.0 || ^3.0 || ^4.0 || ^5.0",
+        "phpunit/php-file-iterator": "^3.0 || ^4.0 || ^5.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
This library is being used by [wnx/laravel-stats](https://github.com/stefanzweifel/laravel-stats). Updated dependency list allows upgrading projects to PHPUnit v11.